### PR TITLE
Provide access to the local port used by a connected UdpSocket

### DIFF
--- a/ip/UdpSocket.h
+++ b/ip/UdpSocket.h
@@ -114,12 +114,13 @@ public:
 
 	// Retrieve the local endpoint name when sending to 'to'
 	IpEndpointName LocalEndpointFor( const IpEndpointName& remoteEndpoint ) const;
+	IpEndpointName LocalEndpointForConnectedRemoteEndpoint() const;
 
 	// Connect to a remote endpoint which is used as the target
 	// for calls to Send()
 	void Connect( const IpEndpointName& remoteEndpoint, bool enableBroadcast = false );
 	void Send( const char *data, std::size_t size );
-    void SendTo( const IpEndpointName& remoteEndpoint, const char *data, std::size_t size );
+	void SendTo( const IpEndpointName& remoteEndpoint, const char *data, std::size_t size );
 
 
 	// Bind a local endpoint to receive incoming data. Endpoint

--- a/tests/OscSendTests.cpp
+++ b/tests/OscSendTests.cpp
@@ -61,6 +61,12 @@ void RunSendTests( const IpEndpointName& host )
     osc::OutboundPacketStream p( buffer, IP_MTU_SIZE );
 	UdpTransmitSocket socket( host );
 
+    osc::IpEndpointName localEndpoint = socket.LocalEndpointForConnectedRemoteEndpoint();
+    osc::IpEndpointName localEndpoint2 = socket.LocalEndpointFor(host);
+    if (localEndpoint != localEndpoint2) {
+        std::cout << "error: local endpoints should have been the same for remote connection\n";
+    }
+
     p.Clear();
     p << osc::BeginMessage( "/test1" )
             << true << 23 << (float)3.1415 << "hello" << osc::EndMessage;


### PR DESCRIPTION
- add new method LocalEndpointForConnectedRemoteEndpoint(), and modify
  LocalEndpointFor() to work when the socket is connected.
- lets a UdpTransmitSocket find out which local port it's using to
  send, allowing the possibility to open a receiver socket on that
  port and thereby send and receive on the same local port.  This
  makes things easy and symmetrical for client/server uses; the server
  can simply reply to the ports from which it receives client
  messages.
- includes code from @RossBencina, after a discussion in August 2014.
